### PR TITLE
files.go - increase default buffer size

### DIFF
--- a/pkg/files.go
+++ b/pkg/files.go
@@ -164,6 +164,10 @@ func FileStats(filePath string, isRemote bool, sshConfig *SSHConfig) (int, int64
 
 	var linesCount int
 	scanner := bufio.NewScanner(reader)
+	// Increase buffer size to 10MB
+	buf := make([]byte, 10*1024*1024) // 10MB buffer
+	scanner.Buffer(buf, len(buf))
+
 	for scanner.Scan() {
 		linesCount++
 	}


### PR DESCRIPTION
from this Solved answer [issue](https://github.com/shukurew/LogViewer/commit/7132a0cf40ab6af4a23324591eee50b4f99c944b) 